### PR TITLE
prevent looking in the URL for session

### DIFF
--- a/template-typescript-bottom-tabs-supabase-auth-flow/src/initSupabase.ts
+++ b/template-typescript-bottom-tabs-supabase-auth-flow/src/initSupabase.ts
@@ -4,4 +4,5 @@ import { createClient } from "@supabase/supabase-js";
 // Better put your these secret keys in .env file
 export const supabase = createClient("supabaseUrl", "supabaseKey", {
   localStorage: AsyncStorage as any,
+  detectSessionInUrl: false // Prevents Supabase from evaluating window.location.href, breaking mobile
 });


### PR DESCRIPTION
Prevents Supabase client from looking at the URL for a session, which was breaking mobile. 

Fixes #15 